### PR TITLE
chore: further gas optimization

### DIFF
--- a/contracts/Rln.sol
+++ b/contracts/Rln.sol
@@ -36,7 +36,9 @@ contract RLN {
         poseidonHasher = IPoseidonHasher(_poseidonHasher);
         SET_SIZE = 1 << DEPTH;
         if (constructMembers.length > SET_SIZE) revert FullTree();
-        for (uint256 i = 0; i < constructMembers.length;) {
+
+        uint256 len = constructMembers.length;
+        for (uint256 i = 0; i < len;) {
             _register(constructMembers[i]);
             unchecked {
                 ++i;


### PR DESCRIPTION
Sorry, forgot this one in the previous PR

Storing length of an array in memory and then using it for the check is cheaper (for bigger arrays) than reading the length for each iteration.