### PR TITLE
fix: forceProgression led to an invalid state, bricking the contract

### DIFF
--- a/contracts/WakuRlnRegistry.sol
+++ b/contracts/WakuRlnRegistry.sol
@@ -48,7 +48,7 @@ contract WakuRlnRegistry is Ownable {
         _insertIntoStorageMap(address(newStorageContract));
     }
 
-    function register(uint256[] calldata commitments) external payable onlyUsableStorage {
+    function register(uint256[] calldata commitments) external onlyUsableStorage {
         // iteratively check if the storage contract is full, and increment the usingStorageIndex if it is
         while (true) {
             try WakuRln(storages[usingStorageIndex]).register(commitments) {
@@ -67,12 +67,12 @@ contract WakuRlnRegistry is Ownable {
         }
     }
 
-    function register(uint16 storageIndex, uint256[] calldata commitments) external payable {
+    function register(uint16 storageIndex, uint256[] calldata commitments) external {
         if (storageIndex >= nextStorageIndex) revert NoStorageContractAvailable();
         WakuRln(storages[storageIndex]).register(commitments);
     }
 
-    function register(uint16 storageIndex, uint256 commitment) external payable {
+    function register(uint16 storageIndex, uint256 commitment) external {
         if (storageIndex >= nextStorageIndex) revert NoStorageContractAvailable();
         // optimize the gas used below
         uint256[] memory commitments = new uint256[](1);

--- a/contracts/WakuRlnRegistry.sol
+++ b/contracts/WakuRlnRegistry.sol
@@ -81,6 +81,7 @@ contract WakuRlnRegistry is Ownable {
     }
 
     function forceProgress() external onlyOwner onlyUsableStorage {
+        if (storages[usingStorageIndex + 1] == address(0)) revert NoStorageContractAvailable();
         usingStorageIndex += 1;
     }
 }

--- a/deploy/003_deploy_rln.ts
+++ b/deploy/003_deploy_rln.ts
@@ -37,7 +37,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     solcInput: extendedArtifact.solcInput,
     devdoc: extendedArtifact.devdoc,
   };
-  console.log(d);
   deployments.save(`WakuRlnStorage_${indexOfStorageToBeDeployed}`, d);
 };
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -181,19 +181,19 @@ function newStorage() external
 ### register
 
 ```solidity
-function register(uint256[] commitments) external payable
+function register(uint256[] commitments) external
 ```
 
 ### register
 
 ```solidity
-function register(uint16 storageIndex, uint256[] commitments) external payable
+function register(uint16 storageIndex, uint256[] commitments) external
 ```
 
 ### register
 
 ```solidity
-function register(uint16 storageIndex, uint256 commitment) external payable
+function register(uint16 storageIndex, uint256 commitment) external
 ```
 
 ### forceProgress

--- a/test/WakuRlnRegistry.t.sol
+++ b/test/WakuRlnRegistry.t.sol
@@ -53,8 +53,10 @@ contract WakuRlnRegistryTest is Test {
 
     function test__forceProgression() public {
         wakuRlnRegistry.newStorage();
+        wakuRlnRegistry.newStorage();
         wakuRlnRegistry.forceProgress();
-        require(wakuRlnRegistry.usingStorageIndex() == 1);
+        assertEq(wakuRlnRegistry.usingStorageIndex(), 1);
+        assertEq(wakuRlnRegistry.nextStorageIndex(), 2);
     }
 
     function test__SingleRegistration(uint256 commitment) public {
@@ -104,5 +106,12 @@ contract WakuRlnRegistryTest is Test {
         );
         vm.expectRevert(NoStorageContractAvailable.selector);
         wakuRlnRegistry.register(commitments);
+    }
+
+    function test__forceProgression__NoStorageContract() public {
+        vm.expectRevert(NoStorageContractAvailable.selector);
+        wakuRlnRegistry.forceProgress();
+        assertEq(wakuRlnRegistry.usingStorageIndex(), 0);
+        assertEq(wakuRlnRegistry.nextStorageIndex(), 0);
     }
 }


### PR DESCRIPTION
We need to check these states -
1. on contract startup, usingStorageIndex and nextStorageIndex == 0
2. after a new storage, usingStorageIndex == 0, nextStorageIndex == 1
3. If forceProgression is applied, check if usingStorageIndex + 1 has a valid storage
4. If forceProgression is applied on contract creation, should error out

previously, 3 & 4 were not tested, now they are.


