### PR TITLE
feat: membership TTL

### DIFF
--- a/contracts/WakuRln.sol
+++ b/contracts/WakuRln.sol
@@ -7,25 +7,46 @@ import {Ownable} from "openzeppelin-contracts/contracts/access/Ownable.sol";
 
 error NotImplemented();
 
+error InvalidIdCommitmentIndex(uint256 idCommitment, uint256 index);
+
+error MembershipStillActive(uint256 idCommitment);
+
 contract WakuRln is Ownable, RlnBase {
     uint16 public immutable contractIndex;
 
+    /// @notice The default TTL period in seconds for a membership
+    uint256 public immutable MEMBERSHIP_TTL;
+
+    /// @notice The expiry timestamp of a membership
+    /// maps from idCommitment to a timestamp
+    mapping(uint256 => uint256) public membershipExpiry;
+
     constructor(
         address _poseidonHasher,
-        uint16 _contractIndex
+        uint16 _contractIndex,
+        uint256 _ttl
     ) Ownable() RlnBase(0, 20, _poseidonHasher, address(0)) {
         contractIndex = _contractIndex;
+        MEMBERSHIP_TTL = _ttl;
+    }
+
+    function _setCommitment(uint256 idCommitment, uint256 index) internal {
+        _validateRegistration(idCommitment);
+
+        members[idCommitment] = index;
+        memberExists[idCommitment] = true;
+        membershipExpiry[idCommitment] = block.timestamp + MEMBERSHIP_TTL;
+
+        emit MemberRegistered(idCommitment, index);
     }
 
     /// Registers a member
     /// @param idCommitment The idCommitment of the member
     function _register(uint256 idCommitment) internal {
-        _validateRegistration(idCommitment);
+        if (idCommitmentIndex >= SET_SIZE) revert FullTree();
 
-        members[idCommitment] = idCommitmentIndex;
-        memberExists[idCommitment] = true;
+        _setCommitment(idCommitment, idCommitmentIndex);
 
-        emit MemberRegistered(idCommitment, idCommitmentIndex);
         idCommitmentIndex += 1;
     }
 
@@ -37,6 +58,27 @@ contract WakuRln is Ownable, RlnBase {
                 ++i;
             }
         }
+    }
+
+    /// Register a member at specific index
+    /// @param idCommitment The idCommitment of the member
+    /// @param index The index in which to register the member
+    function registerAtIndex(uint256 idCommitment, uint256 index) external onlyOwner {
+        _validateIndexExpiration(idCommitment, index);
+        _setCommitment(idCommitment, index);
+    }
+
+    /// Renew membership credentials
+    function renew(uint256 idCommitment /*, uint256 periods*/) external onlyOwner {
+        // TODO: should this function be payable, and also, accept renewals for more than 1 period?
+        // if (msg.value != periods * MEMBERSHIP_DEPOSIT) revert InvalidTransactionValue()
+
+        // TODO: should we allow renewals using a grace period?
+
+        uint256 expiry = membershipExpiry[idCommitment];
+        if (expiry == 0) revert InvalidIdCommitment(idCommitment);
+
+        membershipExpiry[idCommitment] += MEMBERSHIP_TTL /* * periods */;
     }
 
     function register(uint256 idCommitment) external payable override {
@@ -57,7 +99,14 @@ contract WakuRln is Ownable, RlnBase {
         if (!isValidCommitment(idCommitment))
             revert InvalidIdCommitment(idCommitment);
         if (memberExists[idCommitment] == true) revert DuplicateIdCommitment();
-        if (idCommitmentIndex >= SET_SIZE) revert FullTree();
+    }
+
+    function _validateIndexExpiration(
+        uint256 idCommitment,
+        uint256 index
+    ) internal view {
+        if (index >= SET_SIZE) revert InvalidIdCommitmentIndex(idCommitment, index);
+        if (membershipExpiry[idCommitment] > block.timestamp) revert MembershipStillActive(idCommitment);
     }
 
     function _validateSlash(

--- a/contracts/WakuRln.sol
+++ b/contracts/WakuRln.sol
@@ -15,16 +15,16 @@ contract WakuRln is Ownable, RlnBase {
     uint16 public immutable contractIndex;
 
     /// @notice The default TTL period in seconds for a membership
-    uint256 public immutable MEMBERSHIP_TTL;
+    uint40 public immutable MEMBERSHIP_TTL;
 
     /// @notice The expiry timestamp of a membership
     /// maps from idCommitment to a timestamp
-    mapping(uint256 => uint256) public membershipExpiry;
+    mapping(uint256 => uint40) public membershipExpiry;
 
     constructor(
         address _poseidonHasher,
         uint16 _contractIndex,
-        uint256 _ttl
+        uint40 _ttl
     ) Ownable() RlnBase(0, 20, _poseidonHasher, address(0)) {
         contractIndex = _contractIndex;
         MEMBERSHIP_TTL = _ttl;
@@ -35,7 +35,7 @@ contract WakuRln is Ownable, RlnBase {
 
         members[idCommitment] = index;
         memberExists[idCommitment] = true;
-        membershipExpiry[idCommitment] = block.timestamp + MEMBERSHIP_TTL;
+        membershipExpiry[idCommitment] = uint40(block.timestamp) + MEMBERSHIP_TTL;
 
         emit MemberRegistered(idCommitment, index);
     }

--- a/deploy/002_deploy_rln_registry.ts
+++ b/deploy/002_deploy_rln_registry.ts
@@ -16,9 +16,14 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     log: true,
   });
 
-  let initializeAbi = ["function initialize(address _poseidonHasher)"];
+  let initializeAbi = [
+    "function initialize(address _poseidonHasher, uint40 _ttl)",
+  ];
   let iface = new hre.ethers.utils.Interface(initializeAbi);
-  const data = iface.encodeFunctionData("initialize", [poseidonHasherAddress]);
+  const data = iface.encodeFunctionData("initialize", [
+    poseidonHasherAddress,
+    0,
+  ]);
 
   await deploy("WakuRlnRegistry_Proxy", {
     contract: "ERC1967Proxy",

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,18 @@
 error NotImplemented()
 ```
 
+## InvalidIdCommitmentIndex
+
+```solidity
+error InvalidIdCommitmentIndex(uint256 idCommitment, uint256 index)
+```
+
+## MembershipStillActive
+
+```solidity
+error MembershipStillActive(uint256 idCommitment)
+```
+
 ## WakuRln
 
 ### contractIndex
@@ -14,13 +26,36 @@ error NotImplemented()
 uint16 contractIndex
 ```
 
+### MEMBERSHIP_TTL
+
+```solidity
+uint40 MEMBERSHIP_TTL
+```
+
+The default TTL period in seconds for a membership
+
+### membershipExpiry
+
+```solidity
+mapping(uint256 => uint40) membershipExpiry
+```
+
+The expiry timestamp of a membership
+maps from idCommitment to a timestamp
+
 ### constructor
 
 ```solidity
-constructor(address _poseidonHasher, uint16 _contractIndex) public
+constructor(address _poseidonHasher, uint16 _contractIndex, uint40 _ttl) public
 ```
 
-### _register
+### \_setCommitment
+
+```solidity
+function _setCommitment(uint256 idCommitment, uint256 index) internal
+```
+
+### \_register
 
 ```solidity
 function _register(uint256 idCommitment) internal
@@ -30,8 +65,8 @@ Registers a member
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name         | Type    | Description                    |
+| ------------ | ------- | ------------------------------ |
 | idCommitment | uint256 | The idCommitment of the member |
 
 ### register
@@ -39,6 +74,29 @@ Registers a member
 ```solidity
 function register(uint256[] idCommitments) external
 ```
+
+### registerAtIndex
+
+```solidity
+function registerAtIndex(uint256 idCommitment, uint256 index) external
+```
+
+Register a member at specific index
+
+#### Parameters
+
+| Name         | Type    | Description                               |
+| ------------ | ------- | ----------------------------------------- |
+| idCommitment | uint256 | The idCommitment of the member            |
+| index        | uint256 | The index in which to register the member |
+
+### renew
+
+```solidity
+function renew(uint256 idCommitment) external
+```
+
+Renew membership credentials
 
 ### register
 
@@ -50,8 +108,8 @@ Allows a user to register as a member
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name         | Type    | Description                    |
+| ------------ | ------- | ------------------------------ |
 | idCommitment | uint256 | The idCommitment of the member |
 
 ### slash
@@ -64,13 +122,13 @@ _Allows a user to slash a member_
 
 #### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| idCommitment | uint256 | The idCommitment of the member |
-| receiver | address payable |  |
-| proof | uint256[8] |  |
+| Name         | Type            | Description                    |
+| ------------ | --------------- | ------------------------------ |
+| idCommitment | uint256         | The idCommitment of the member |
+| receiver     | address payable |                                |
+| proof        | uint256[8]      |                                |
 
-### _validateRegistration
+### \_validateRegistration
 
 ```solidity
 function _validateRegistration(uint256 idCommitment) internal view
@@ -78,7 +136,13 @@ function _validateRegistration(uint256 idCommitment) internal view
 
 _Inheriting contracts MUST override this function_
 
-### _validateSlash
+### \_validateIndexExpiration
+
+```solidity
+function _validateIndexExpiration(uint256 idCommitment, uint256 index) internal view
+```
+
+### \_validateSlash
 
 ```solidity
 function _validateSlash(uint256 idCommitment, address payable receiver, uint256[8] proof) internal pure
@@ -142,6 +206,12 @@ uint16 usingStorageIndex
 contract IPoseidonHasher poseidonHasher
 ```
 
+### membershipTTL
+
+```solidity
+uint40 membershipTTL
+```
+
 ### NewStorageContract
 
 ```solidity
@@ -157,21 +227,21 @@ modifier onlyUsableStorage()
 ### initialize
 
 ```solidity
-function initialize(address _poseidonHasher) external
+function initialize(address _poseidonHasher, uint40 _membershipTTL) external
 ```
 
-### _authorizeUpgrade
+### \_authorizeUpgrade
 
 ```solidity
 function _authorizeUpgrade(address newImplementation) internal
 ```
 
-_Function that should revert when `msg.sender` is not authorized to upgrade the contract. Called by
+\_Function that should revert when `msg.sender` is not authorized to upgrade the contract. Called by
 {upgradeTo} and {upgradeToAndCall}.
 
 Normally, this function will use an xref:access.adoc[access control] modifier such as {Ownable-onlyOwner}.
 
-```solidity
+````solidity
 function _authorizeUpgrade(address) internal override onlyOwner {}
 ```_
 
@@ -179,7 +249,7 @@ function _authorizeUpgrade(address) internal override onlyOwner {}
 
 ```solidity
 function _insertIntoStorageMap(address storageAddress) internal
-```
+````
 
 ### registerStorage
 
@@ -211,9 +281,14 @@ function register(uint16 storageIndex, uint256[] commitments) external
 function register(uint16 storageIndex, uint256 commitment) external
 ```
 
+### registerAtIndex
+
+```solidity
+function registerAtIndex(uint16 storageIndex, uint256 commitment, uint256 index) external
+```
+
 ### forceProgress
 
 ```solidity
 function forceProgress() external
 ```
-

--- a/test/WakuRln.t.sol
+++ b/test/WakuRln.t.sol
@@ -16,13 +16,14 @@ contract WakuRlnTest is Test {
     uint256 public constant MEMBERSHIP_DEPOSIT = 1000000000000000;
     uint256 public constant DEPTH = 20;
     uint256 public constant SET_SIZE = 1048576;
+    uint40 public constant TTL = 100;
 
     uint256[8] public zeroedProof = [0, 0, 0, 0, 0, 0, 0, 0];
 
     /// @dev Setup the testing environment.
     function setUp() public {
         poseidon = new PoseidonHasher();
-        wakuRln = new WakuRln(address(poseidon), 0);
+        wakuRln = new WakuRln(address(poseidon), 0, TTL);
     }
 
     /// @dev Ensure that you can hash a value.

--- a/test/WakuRlnRegistry.t.sol
+++ b/test/WakuRlnRegistry.t.sol
@@ -19,7 +19,7 @@ contract WakuRlnRegistryTest is Test {
     function setUp() public {
         poseidonHasher = new PoseidonHasher();
         address implementation = address(new WakuRlnRegistry());
-        bytes memory data = abi.encodeCall(WakuRlnRegistry.initialize, address(poseidonHasher));
+        bytes memory data = abi.encodeCall(WakuRlnRegistry.initialize, (address(poseidonHasher), 0));
         address proxy = address(new ERC1967Proxy(implementation, data));
         wakuRlnRegistry = WakuRlnRegistry(proxy);
     }
@@ -29,14 +29,14 @@ contract WakuRlnRegistryTest is Test {
     }
 
     function test__RegisterStorage_BadIndex() public {
-        wakuRlnRegistry.registerStorage(address(new WakuRln(address(poseidonHasher), 0)));
-        address newStorage = address(new WakuRln(address(poseidonHasher), 0));
+        wakuRlnRegistry.registerStorage(address(new WakuRln(address(poseidonHasher), 0, 0)));
+        address newStorage = address(new WakuRln(address(poseidonHasher), 0, 0));
         vm.expectRevert(IncompatibleStorageIndex.selector);
         wakuRlnRegistry.registerStorage(newStorage);
     }
 
     function test__RegisterStorage_BadImpl() public {
-        address newStorage = address(new WakuRln(address(new PoseidonHasher()), 0));
+        address newStorage = address(new WakuRln(address(new PoseidonHasher()), 0, 0));
         vm.expectRevert(IncompatibleStorage.selector);
         wakuRlnRegistry.registerStorage(newStorage);
     }


### PR DESCRIPTION
This PR is an attempt to introduce membership expiration. 
It's worth mentioning that currently the registry and renewal functions are not payable, so in practice introducing a TTL has no meaning, since someone could still call the `renew` function and set their expiration date really far in the future.

If we decide to continue with the free registration approach, would it make sense to introduce a grace period on which the credential owner can renew their membership credential for one period. Or perhaps while the registration period is free, the renewal has a cost?

I'm missing background on the plan behind the expiration for membership credentials so not sure what approach to take :)