### PR TITLE
chore: deprecation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Hardhat Project for rln-contract
+# Hardhat Project for waku-rlnv1-contract
+
+> note: This repo is being archived in favour of the rln-v2 contracts for waku.
 
 ## Requirements
 


### PR DESCRIPTION
To deprecate this repo in favour of rln-v2 contracts which will be standalone instead of inheriting the vacp2p/rln-contract abstract
